### PR TITLE
[RTM] Hotfix save empty string as null

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -8,4 +8,5 @@ For documentation visit:
 -->
 <project name="metamodels/attribute-longtext" default="build">
   <import file="vendor/phpcq/phpcq/phpcq.main.xml"/>
+  <target name="phpspec" />
 </project>

--- a/src/Attribute/Longtext.php
+++ b/src/Attribute/Longtext.php
@@ -69,4 +69,14 @@ class Longtext extends BaseSimple
 
         return $arrFieldDef;
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * This is needed for compatibility with MySQL strict mode.
+     */
+    public function serializeData($value)
+    {
+        return $value === '' ? null : $value;
+    }
 }


### PR DESCRIPTION
Hotfix save empty string as null

see https://github.com/MetaModels/core/issues/1330